### PR TITLE
Fix GOPATH and GOFLAGS

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -50,11 +50,12 @@ prepare() {
 
 build() {
   cd "${_pkgname}/cmd/caddy/"
+  export GOPATH="$srcdir"/gopath
   export CGO_LDFLAGS="${LDFLAGS}"
   export CGO_CPPFLAGS="${CPPFLAGS}"
   export CGO_CFLAGS="${CFLAGS}"
   export CGO_CXXFLAGS="${CXXFLAGS}"
-  export GOFLAGS="-buildmode=pie -trimpath"
+  export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
   go build .
 }
 


### PR DESCRIPTION
I added two of the GOPATHs that the Go packaging guidelines recommended, and I changed the GOPATH to be inside the package directory so it doesn't pollute `~/go` (the aur package for `yay` does that as well). 